### PR TITLE
Fix incorrect syntax for xref in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule CldrDatesTimes.Mixfile do
         plt_add_apps: ~w(calendar_interval)a
       ],
       xref: [
-        exclude: :eprof
+        exclude: [:eprof]
       ]
     ]
   end


### PR DESCRIPTION
The [documentation](https://hexdocs.pm/mix/Mix.Tasks.Compile.Elixir.html#module-configuration) specifies this should be a list of `module` or `{module, function, arity}`.

The current configuration causes this error trace:

```
could not compile dependency :ex_cldr_dates_times, "mix compile" failed. You can recompile this dependency with "mix deps.compile ex_cldr_dates_times", update it with "mix deps.update ex_cldr_dates_times" or clean it with "mix deps.clean ex_cldr_dates_times"
** (Protocol.UndefinedError) protocol Enumerable not implemented for :eprof
    (elixir) lib/enum.ex:1: Enumerable.impl_for!/1
    (elixir) lib/enum.ex:141: Enumerable.reduce/3
    (elixir) lib/enum.ex:3015: Enum.reverse/1
    (elixir) lib/enum.ex:2649: Enum.to_list/1
    (elixir) lib/map_set.ex:78: MapSet.new/1
    (mix) lib/mix/tasks/xref.ex:189: Mix.Tasks.Xref.warnings/1
    (mix) lib/mix/tasks/compile.xref.ex:56: Mix.Tasks.Compile.Xref.run_xref/0
    (mix) lib/mix/tasks/compile.xref.ex:38: Mix.Tasks.Compile.Xref.run/1
```

on [Elixir 1.8.2](https://github.com/elixir-lang/elixir/blob/v1.8.2/lib/mix/lib/mix/tasks/xref.ex#L423-L428) (and probably in other versions).

Or maybe the whole `:xref` configuration should be removed 🙂 