### PR TITLE
Change license metadata field to a valid SPDX identifier

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -82,7 +82,7 @@ defmodule CldrDatesTimes.Mixfile do
   defp package do
     [
       maintainers: ["Kip Cole"],
-      licenses: ["Apache 2.0"],
+      licenses: ["Apache-2.0"],
       links: links(),
       files: [
         "lib",


### PR DESCRIPTION
Not mandatory, but recommended for hex.pm. https://hex.pm/docs/publish#adding-metadata-to-code-classinlinemixexscode

Can be useful for a project like https://github.com/Cantido/hex_licenses

Related: https://github.com/elixir-cldr/cldr/pull/155