### PR TITLE
Update `CLDR` references to `Cldr` in docs

### DIFF
--- a/lib/cldr/backend/interval.ex
+++ b/lib/cldr/backend/interval.ex
@@ -113,7 +113,7 @@ defmodule Cldr.Interval.Backend do
         * The available predefined formats that can be applied are the
           keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
           where `"en"` can be replaced by any configuration locale name and `:gregorian`
-          is the underlying `CLDR` calendar type.
+          is the underlying `Cldr` calendar type.
 
         * In the case where `from` and `to` are equal, a single
           date, time or datetime is formatted instead of an interval
@@ -223,7 +223,7 @@ defmodule Cldr.Interval.Backend do
         * The available predefined formats that can be applied are the
           keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
           where `"en"` can be replaced by any configuration locale name and `:gregorian`
-          is the underlying `CLDR` calendar type.
+          is the underlying `Cldr` calendar type.
 
         * In the case where `from` and `to` are equal, a single
           date, time or datetime is formatted instead of an interval
@@ -353,7 +353,7 @@ defmodule Cldr.Interval.Backend do
         * The available predefined formats that can be applied are the
           keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
           where `"en"` can be replaced by any configuration locale name and `:gregorian`
-          is the underlying `CLDR` calendar type.
+          is the underlying `Cldr` calendar type.
 
         * In the case where `from` and `to` are equal, a single
           date, time or datetime is formatted instead of an interval
@@ -464,7 +464,7 @@ defmodule Cldr.Interval.Backend do
         * The available predefined formats that can be applied are the
           keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
           where `"en"` can be replaced by any configuration locale name and `:gregorian`
-          is the underlying `CLDR` calendar type.
+          is the underlying `Cldr` calendar type.
 
         * In the case where `from` and `to` are equal, a single
           date, time or datetime is formatted instead of an interval

--- a/lib/cldr/backend/interval/date.ex
+++ b/lib/cldr/backend/interval/date.ex
@@ -83,7 +83,7 @@ defmodule Cldr.Date.Interval.Backend do
         * The available predefined formats that can be applied are the
           keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
           where `"en"` can be replaced by any configuration locale name and `:gregorian`
-          is the underlying `CLDR` calendar type.
+          is the underlying `Cldr` calendar type.
 
         * In the case where `from` and `to` are equal, a single
           date is formatted instead of an interval
@@ -192,7 +192,7 @@ defmodule Cldr.Date.Interval.Backend do
         * The available predefined formats that can be applied are the
           keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
           where `"en"` can be replaced by any configuration locale name and `:gregorian`
-          is the underlying `CLDR` calendar type.
+          is the underlying `Cldr` calendar type.
 
         * In the case where `from` and `to` are equal, a single
           date is formatted instead of an interval
@@ -300,7 +300,7 @@ defmodule Cldr.Date.Interval.Backend do
         * The available predefined formats that can be applied are the
           keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
           where `"en"` can be replaced by any configuration locale name and `:gregorian`
-          is the underlying `CLDR` calendar type.
+          is the underlying `Cldr` calendar type.
 
         * In the case where `from` and `to` are equal, a single
           date is formatted instead of an interval
@@ -406,7 +406,7 @@ defmodule Cldr.Date.Interval.Backend do
         * The available predefined formats that can be applied are the
           keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
           where `"en"` can be replaced by any configuration locale name and `:gregorian`
-          is the underlying `CLDR` calendar type.
+          is the underlying `Cldr` calendar type.
 
         * In the case where `from` and `to` are equal, a single
           date is formatted instead of an interval

--- a/lib/cldr/backend/interval/date_time.ex
+++ b/lib/cldr/backend/interval/date_time.ex
@@ -77,7 +77,7 @@ defmodule Cldr.DateTime.Interval.Backend do
           * The available predefined formats that can be applied are the
             keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
             where `"en"` can be replaced by any configuration locale name and `:gregorian`
-            is the underlying `CLDR` calendar type.
+            is the underlying `Cldr` calendar type.
 
           * In the case where `from` and `to` are equal, a single
             date is formatted instead of an interval
@@ -149,7 +149,7 @@ defmodule Cldr.DateTime.Interval.Backend do
         * The available predefined formats that can be applied are the
           keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
           where `"en"` can be replaced by any configuration locale name and `:gregorian`
-          is the underlying `CLDR` calendar type.
+          is the underlying `Cldr` calendar type.
 
         * In the case where `from` and `to` are equal, a single
           date is formatted instead of an interval
@@ -237,7 +237,7 @@ defmodule Cldr.DateTime.Interval.Backend do
           * The available predefined formats that can be applied are the
             keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
             where `"en"` can be replaced by any configuration locale name and `:gregorian`
-            is the underlying `CLDR` calendar type.
+            is the underlying `Cldr` calendar type.
 
           * In the case where `from` and `to` are equal, a single
             date is formatted instead of an interval
@@ -306,7 +306,7 @@ defmodule Cldr.DateTime.Interval.Backend do
         * The available predefined formats that can be applied are the
           keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
           where `"en"` can be replaced by any configuration locale name and `:gregorian`
-          is the underlying `CLDR` calendar type.
+          is the underlying `Cldr` calendar type.
 
         * In the case where `from` and `to` are equal, a single
           date is formatted instead of an interval.

--- a/lib/cldr/backend/interval/time.ex
+++ b/lib/cldr/backend/interval/time.ex
@@ -71,7 +71,7 @@ defmodule Cldr.Time.Interval.Backend do
         * The available predefined formats that can be applied are the
           keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
           where `"en"` can be replaced by any configured locale name and `:gregorian`
-          is the underlying `CLDR` calendar type.
+          is the underlying `Cldr` calendar type.
 
         * In the case where `from` and `to` are equal, a single
           time is formatted instead of an interval
@@ -180,7 +180,7 @@ defmodule Cldr.Time.Interval.Backend do
         * The available predefined formats that can be applied are the
           keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
           where `"en"` can be replaced by any configured locale name and `:gregorian`
-          is the underlying `CLDR` calendar type.
+          is the underlying `Cldr` calendar type.
 
         * In the case where `from` and `to` are equal, a single
           time is formatted instead of an interval

--- a/lib/cldr/interval.ex
+++ b/lib/cldr/interval.ex
@@ -398,7 +398,7 @@ defmodule Cldr.Interval do
   * The available predefined formats that can be applied are the
     keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
     where `"en"` can be replaced by any configuration locale name and `:gregorian`
-    is the underlying `CLDR` calendar type.
+    is the underlying `Cldr` calendar type.
 
   * In the case where `from` and `to` are equal, a single
     date, time or datetime is formatted instead of an interval
@@ -529,7 +529,7 @@ defmodule Cldr.Interval do
   * The available predefined formats that can be applied are the
     keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
     where `"en"` can be replaced by any configuration locale name and `:gregorian`
-    is the underlying `CLDR` calendar type.
+    is the underlying `Cldr` calendar type.
 
   * In the case where `from` and `to` are equal, a single
     date, time or datetime is formatted instead of an interval
@@ -681,7 +681,7 @@ defmodule Cldr.Interval do
   * The available predefined formats that can be applied are the
     keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
     where `"en"` can be replaced by any configuration locale name and `:gregorian`
-    is the underlying `CLDR` calendar type.
+    is the underlying `Cldr` calendar type.
 
   * In the case where `from` and `to` are equal, a single
     date, time or datetime is formatted instead of an interval
@@ -800,7 +800,7 @@ defmodule Cldr.Interval do
   * The available predefined formats that can be applied are the
     keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
     where `"en"` can be replaced by any configuration locale name and `:gregorian`
-    is the underlying `CLDR` calendar type.
+    is the underlying `Cldr` calendar type.
 
   * In the case where `from` and `to` are equal, a single
     date, time or datetime is formatted instead of an interval

--- a/lib/cldr/interval/date.ex
+++ b/lib/cldr/interval/date.ex
@@ -185,7 +185,7 @@ defmodule Cldr.Date.Interval do
   * The available predefined formats that can be applied are the
     keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
     where `"en"` can be replaced by any configuration locale name and `:gregorian`
-    is the underlying `CLDR` calendar type.
+    is the underlying `Cldr` calendar type.
 
   * In the case where `from` and `to` are equal, a single
     date is formatted instead of an interval
@@ -292,7 +292,7 @@ defmodule Cldr.Date.Interval do
   * The available predefined formats that can be applied are the
     keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
     where `"en"` can be replaced by any configuration locale name and `:gregorian`
-    is the underlying `CLDR` calendar type.
+    is the underlying `Cldr` calendar type.
 
   * In the case where `from` and `to` are equal, a single
     date is formatted instead of an interval
@@ -501,7 +501,7 @@ defmodule Cldr.Date.Interval do
   * The available predefined formats that can be applied are the
     keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
     where `"en"` can be replaced by any configuration locale name and `:gregorian`
-    is the underlying `CLDR` calendar type.
+    is the underlying `Cldr` calendar type.
 
   * In the case where `from` and `to` are equal, a single
     date is formatted instead of an interval
@@ -602,7 +602,7 @@ defmodule Cldr.Date.Interval do
   * The available predefined formats that can be applied are the
     keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
     where `"en"` can be replaced by any configuration locale name and `:gregorian`
-    is the underlying `CLDR` calendar type.
+    is the underlying `Cldr` calendar type.
 
   * In the case where `from` and `to` are equal, a single
     date is formatted instead of an interval

--- a/lib/cldr/interval/date_time.ex
+++ b/lib/cldr/interval/date_time.ex
@@ -81,7 +81,7 @@ defmodule Cldr.DateTime.Interval do
     * The available predefined formats that can be applied are the
       keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
       where `"en"` can be replaced by any configuration locale name and `:gregorian`
-      is the underlying `CLDR` calendar type.
+      is the underlying `Cldr` calendar type.
 
     * In the case where `from` and `to` are equal, a single
       datetime is formatted instead of an interval
@@ -229,7 +229,7 @@ defmodule Cldr.DateTime.Interval do
   * The available predefined formats that can be applied are the
     keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
     where `"en"` can be replaced by any configuration locale name and `:gregorian`
-    is the underlying `CLDR` calendar type.
+    is the underlying `Cldr` calendar type.
 
   * In the case where `from` and `to` are equal, a single
     date is formatted instead of an interval
@@ -417,7 +417,7 @@ defmodule Cldr.DateTime.Interval do
     * The available predefined formats that can be applied are the
       keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
       where `"en"` can be replaced by any configuration locale name and `:gregorian`
-      is the underlying `CLDR` calendar type.
+      is the underlying `Cldr` calendar type.
 
     * In the case where `from` and `to` are equal, a single
       date is formatted instead of an interval
@@ -489,7 +489,7 @@ defmodule Cldr.DateTime.Interval do
   * The available predefined formats that can be applied are the
     keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
     where `"en"` can be replaced by any configuration locale name and `:gregorian`
-    is the underlying `CLDR` calendar type.
+    is the underlying `Cldr` calendar type.
 
   * In the case where `from` and `to` are equal, a single
     date is formatted instead of an interval

--- a/lib/cldr/interval/time.ex
+++ b/lib/cldr/interval/time.ex
@@ -163,7 +163,7 @@ defmodule Cldr.Time.Interval do
   * The available predefined formats that can be applied are the
     keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
     where `"en"` can be replaced by any configured locale name and `:gregorian`
-    is the underlying `CLDR` calendar type.
+    is the underlying `Cldr` calendar type.
 
   * In the case where `from` and `to` are equal, a single
     time is formatted instead of an interval
@@ -330,7 +330,7 @@ defmodule Cldr.Time.Interval do
   * The available predefined formats that can be applied are the
     keys of the map returned by `Cldr.DateTime.Format.interval_formats("en", :gregorian)`
     where `"en"` can be replaced by any configured locale name and `:gregorian`
-    is the underlying `CLDR` calendar type.
+    is the underlying `Cldr` calendar type.
 
   * In the case where `from` and `to` are equal, a single
     time is formatted instead of an interval


### PR DESCRIPTION
When compiling docs in my applilcation, I see the following message every time I run `mix docs`:

```
11:29:35.752 [error] beam/beam_load.c(180): Error loading module 'Elixir.CLDR':
  module name in object code is 'Elixir.Cldr'
```

After applying the included changes to `cldr_dates_times` and cleaning my build directories, the error disappears.