### PR TITLE
Zero-pad second when formatting 2+ fractional second

### DIFF
--- a/lib/cldr/format/date_time_formatter.ex
+++ b/lib/cldr/format/date_time_formatter.ex
@@ -2859,8 +2859,8 @@ defmodule Cldr.DateTime.Formatter do
   | Symbol | Results    | Description                                           |
   | :----  | :--------- | :---------------------------------------------------- |
   | S      | "4.0"      | Minimum digits of fractional seconds                  |
-  | SS     | "4.00"     | Number of seconds zero-padded to 2 fractional digits  |
-  | SSS    | "4.002"    | Number of seconds zero-padded to 3 fractional digits  |
+  | SS     | "04.00"    | Number of seconds zero-padded to 2 fractional digits  |
+  | SSS    | "04.002"   | Number of seconds zero-padded to 3 fractional digits  |
 
   ## Examples
 
@@ -2868,7 +2868,7 @@ defmodule Cldr.DateTime.Formatter do
       "4.0"
 
       iex> Cldr.DateTime.Formatter.fractional_second %{second: 4, microsecond: {2000, 3}}, 3
-      "4.002"
+      "04.002"
 
       iex> Cldr.DateTime.Formatter.fractional_second %{second: 4}, 1
       "4"
@@ -2911,11 +2911,15 @@ defmodule Cldr.DateTime.Formatter do
         options
       ) do
     rounding = min(resolution, n)
+    n_second = min(2, n)
 
-    (second * 1.0 + fraction / @microseconds)
-    |> Float.round(rounding)
-    |> to_string
-    |> maybe_wrap(:fractional_second, options)
+    [second, fractional_second] =
+      (second * 1.0 + fraction / @microseconds)
+      |> Float.round(rounding)
+      |> to_string
+      |> String.split(".")
+
+    "#{pad(second, n_second)}.#{maybe_wrap(fractional_second, :fractional_second, options)}"
   end
 
   def fractional_second(%{second: second}, n, _locale, _backend, options) do

--- a/test/cldr_dates_times_test.exs
+++ b/test/cldr_dates_times_test.exs
@@ -31,6 +31,23 @@ defmodule Cldr.DatesTimes.Test do
            ) == {:ok, "2018-Jan-01 00:01 AM"}
   end
 
+  test "that the SSS format works as expected" do
+    assert Cldr.DateTime.to_string(
+             %{
+               year: 2018,
+               month: 1,
+               day: 1,
+               hour: 0,
+               minute: 1,
+               second: 0,
+               microsecond: {241_209, 6},
+               calendar: Calendar.ISO
+             },
+             MyApp.Cldr,
+             format: "YYYY-MMM-dd KK:mm:SSS bb"
+           ) == {:ok, "2018-Jan-01 00:01:00.241 AM"}
+  end
+
   test "That localised date doesn't transliterate" do
     assert Cldr.Date.to_string(~D[2019-06-12], MyApp.Cldr, locale: "de") == {:ok, "12.06.2019"}
   end


### PR DESCRIPTION
Honestly, I'm not at all sure what the correct behavior should be here. I was surprised that I couldn't find a way to format seconds to be zero-padded while also including fractional seconds.

By that I mean I received:

```
MyApp.Cldr.DateTime.to_string(value, format: "hh:mm:SSS")
04:58:2.245
```

While I expected:

```
MyApp.Cldr.DateTime.to_string(value, format: "hh:mm:SSS")
04:58:02.245
      ^
```

My initial guess was that the format string should look like `hh:mm:ss.SSS`, but I noticed that `S` included seconds _and_ fractional seconds, so I was trying to figure out how to make it work using only `S` characters.

While working on this PR, I decided to look around to verify that `S` should include both seconds and fractional seconds, and I'm not sure that it should. Looking at https://www.unicode.org/reports/tr35/tr35-dates.html#Matching_Skeletons:

> 3\. A requested skeleton that includes both seconds and fractional seconds (e.g. “mmssSSS”)

That said, @kipcole9, you have much more experience in this domain than I do, so I will defer to your expertise. If there are any changes you'd like me to make to this PR, I am happy to take that on, I also will not be offended if you decide to reject this PR.

Thanks for much for all your amazing libraries and everything you do for the Elixir/BEAM community.