### PR TITLE
Fix crash in adjust_field_length/3 for standalone month format (L)

### DIFF
--- a/lib/cldr/format/match.ex
+++ b/lib/cldr/format/match.ex
@@ -167,7 +167,8 @@ defmodule Cldr.DateTime.Format.Match do
         |> Enum.filter(&candidates_with_the_same_tokens(&1, skeleton_keys))
         |> Enum.map(&distance_from(&1, skeleton_ordered))
         |> Enum.sort(&compare_counts/2)
-        # |> IO.inspect(label: "Candidates")
+
+      # |> IO.inspect(label: "Candidates")
 
       case candidates do
         [] ->
@@ -177,8 +178,8 @@ defmodule Cldr.DateTime.Format.Match do
           {:ok, format_id}
       end
     end
-    # |> IO.inspect(label: "Matched to #{inspect original_skeleton}")
 
+    # |> IO.inspect(label: "Matched to #{inspect original_skeleton}")
   end
 
   @doc false
@@ -554,10 +555,18 @@ defmodule Cldr.DateTime.Format.Match do
   @numeric_and_alpha_fields ["M", "L", "e", "q", "Q"]
   def adjust_field_length([char | _rest] = field, acc, skeleton_tokens)
       when char in @numeric_and_alpha_fields do
-    requested_length = :proplists.get_value(char, skeleton_tokens)
+    requested_length =
+      case :proplists.get_value(char, skeleton_tokens, :not_found) do
+        :not_found -> :proplists.get_value(canonical_key(char), skeleton_tokens, :not_found)
+        length -> length
+      end
+
     field_length = length(field)
 
     cond do
+      requested_length == :not_found ->
+        [field | acc]
+
       field_length == requested_length ->
         [field | acc]
 

--- a/test/formatting_test.exs
+++ b/test/formatting_test.exs
@@ -60,6 +60,21 @@ defmodule Cldr.DateTime.Formatting.Test do
              {:error, {Cldr.DateTime.UnresolvedFormat, "No available format resolved for :dhms"}}
   end
 
+  test "Standalone month format (L) does not crash adjust_field_length/3" do
+    date = ~D[2025-03-15]
+
+    # :MMM resolves to standalone month "LLL" in en and de
+    assert {:ok, _} = Cldr.Date.to_string(date, format: :MMM, locale: "en")
+    assert {:ok, _} = Cldr.Date.to_string(date, format: :MMM, locale: "de")
+
+    # :yMMMM and :yMMM resolve to standalone month in pl
+    assert {:ok, _} = Cldr.Date.to_string(date, format: :yMMMM, locale: "pl")
+    assert {:ok, _} = Cldr.Date.to_string(date, format: :yMMM, locale: "pl")
+
+    # Japanese uses "M" not "L", verify it still works
+    assert {:ok, _} = Cldr.Date.to_string(date, format: :yMMMM, locale: "ja")
+  end
+
   test "That tz format codes are removed from the skeleton before best match if the time is naive" do
     assert {:ok, "October 15, 2025, 1:55:00 PM"} =
              Cldr.DateTime.to_string(~N[2025-10-15T13:55:00], format: :long, time_format: :full)


### PR DESCRIPTION
 - match.ex: Fall back to canonical_key/1 when a format field like "L" isn't found in skeleton tokens, preventing FunctionClauseError in List.duplicate/2
  - formatting_test.exs: Add test for :MMM, :yMMMM, :yMMM across locales that use standalone month

crashed test before fix:
```
1) test Standalone month format (L) does not crash adjust_field_length/3 (Cldr.DateTime.Formatting.Test)
     test/formatting_test.exs:63
     ** (FunctionClauseError) no function clause matching in :lists.duplicate/2

     The following arguments were given to :lists.duplicate/2:

         # 1
         :undefined

         # 2
         "L"

     code: assert {:ok, _} = Cldr.Date.to_string(date, format: :MMM, locale: "en")
     stacktrace:
       (stdlib 7.2) lists.erl:590: :lists.duplicate/2
       (ex_cldr_dates_times 2.25.4) lib/cldr/format/match.ex:569: Cldr.DateTime.Format.Match.adjust_field_length/3
       (elixir 1.19.5) lib/enum.ex:2520: Enum."-reduce/3-lists^foldl/2-0-"/3
       (ex_cldr_dates_times 2.25.4) lib/cldr/format/match.ex:535: Cldr.DateTime.Format.Match.adjust_field_lengths/2
       (ex_cldr_dates_times 2.25.4) lib/cldr/date.ex:186: Cldr.Date.to_string/3
       test/formatting_test.exs:67: (test)
```